### PR TITLE
feat: add quiz repository for quiz flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.test-dist
 certificates

--- a/components/TakeAnswer/MatchTermAnswer.tsx
+++ b/components/TakeAnswer/MatchTermAnswer.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import { CheckCircle, X, XCircle } from "lucide-react";
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import { Answer, Question, QuizTakeQuestion } from '@/component-models/types';
-
-import { get } from '../../services/HttpService';
+import { Answer, QuizTakeQuestion } from '@/component-models/types';
+import { getMatchTermQuestionAnswers, MatchTermQuestionAnswers } from '@/repositories/QuizRepository';
 import { useConfig } from "../providers/ConfigProvider";
 
 interface MatchTermAnswerProps {
@@ -14,46 +13,31 @@ interface MatchTermAnswerProps {
 }
 
 function MatchTermAnswer({ questionId, quizTakeChildren }: MatchTermAnswerProps) {
-    const [questionAnswerDictionary, setQuestionAnswerDictionary] = useState<Map<Question, Answer>>(new Map());
-    const [answers, setAnswers] = useState<Answer[]>([]);
+    const [matchTermItems, setMatchTermItems] = useState<MatchTermQuestionAnswers[]>([]);
 
     const config = useConfig();
 
     useEffect(() => {
         const fetchQuestionAnswers = async () => {
             try {
-                // eslint-disable-next-line max-len
-                const childQuestionsResponse = await get(`Quizzes/PublicQuestion/getList/${config.cityAssociationId}?parentId=${questionId}&ActiveStatusId=0&QuizCategoryId=0&QuizId=0&QuizTheme=None&QuestionType=None&Page=0&SearchTerm=&Type=&Field=&IgnorePageSize=True&PerPage=10`);
-                const childQuestions = childQuestionsResponse.data.list;
-
-                const questionAnswerDict = new Map<Question, Answer>();
-                const allAnswers: Answer[] = [];
-
-                for (const childQuestion of childQuestions) {
-                    // eslint-disable-next-line max-len
-                    const answersResponse = await get(`Quizzes/PublicAnswer/GetList?questionId=${childQuestion.id}&Page=0&SearchTerm=&Type=&Field=&IgnorePageSize=False&PerPage=10`);
-                    const answersData = answersResponse.data.list;
-                    if (!questionAnswerDict.has(childQuestion)) {
-                        questionAnswerDict.set(childQuestion, answersData[0]);
-                    }
-                    allAnswers.push(...answersData);
-                }
-
-                setQuestionAnswerDictionary(questionAnswerDict);
-                setAnswers(allAnswers);
+                const result = await getMatchTermQuestionAnswers(config.cityAssociationId, questionId);
+                setMatchTermItems(result.items);
             } catch (error) {
                 console.error('Error fetching question answers:', error);
             }
         };
 
         fetchQuestionAnswers();
-    }, [questionId]);
+    }, [questionId, config.cityAssociationId]);
+
+    const allAnswers = useMemo(() => matchTermItems.flatMap((item) => item.answers), [matchTermItems]);
 
     return (
         <div className="space-y-6">
-            {Array.from(questionAnswerDictionary.entries()).map(([question, correctAnswer]: [Question, Answer], index) => {
-                const questionTake = quizTakeChildren.find(x => x.questionId === question.id);
+            {matchTermItems.map((item, index) => {
+                const questionTake = quizTakeChildren.find(x => x.questionId === item.question.id);
                 const answer = questionTake?.answers[0];
+                const correctAnswer = item.correctAnswer;
 
                 return (
                     <div key={index} className="space-y-4">
@@ -65,7 +49,7 @@ function MatchTermAnswer({ questionId, quizTakeChildren }: MatchTermAnswerProps)
                                             {index + 1}
                                         </span>
                                     </div>
-                                    <p className="text-base font-medium text-foreground">{question.text}</p>
+                                    <p className="text-base font-medium text-foreground">{item.question.text}</p>
                                 </div>
                             </div>
                             <div>
@@ -78,28 +62,28 @@ function MatchTermAnswer({ questionId, quizTakeChildren }: MatchTermAnswerProps)
                                                     Točan odgovor!
                                                 </p>
                                             </div>
-                                            <div className="flex items-center space-x-3 p-4 border-2 border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-900/20 rounded-lg">
-                                                <span className="text-base font-medium text-green-700 dark:text-green-300">
-                                                    {correctAnswer.text}
-                                                </span>
-                                                <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
-                                            </div>
+                                                <div className="flex items-center space-x-3 p-4 border-2 border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-900/20 rounded-lg">
+                                                    <span className="text-base font-medium text-green-700 dark:text-green-300">
+                                                        {correctAnswer?.text}
+                                                    </span>
+                                                    <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
+                                                </div>
                                         </div>
                                     ) : (
                                         <div className="space-y-3">
-                                            {answers.find(x => x.id === answer.id)?.text ? (
+                                            {allAnswers.find(x => x.id === answer.id)?.text ? (
                                                 <>
                                                     <p className="font-semibold text-lg text-foreground">Tvoj odgovor:</p>
                                                     <div className="flex items-center space-x-3 p-4 border-2 border-red-300 bg-red-50 dark:border-red-700 dark:bg-red-900/20 rounded-lg">
                                                         <span className="text-base font-medium text-red-700 dark:text-red-300">
-                                                            {answers.find(x => x.id === answer.id)?.text}
+                                                            {allAnswers.find(x => x.id === answer.id)?.text}
                                                         </span>
                                                         <XCircle className="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0" />
                                                     </div>
                                                     <p className="font-semibold text-lg text-foreground">Točan odgovor:</p>
                                                     <div className="flex items-center space-x-3 p-4 border-2 border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-900/20 rounded-lg">
                                                         <span className="text-base font-medium text-green-700 dark:text-green-300">
-                                                            {correctAnswer.text}
+                                                            {correctAnswer?.text}
                                                         </span>
                                                         <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
                                                     </div>
@@ -115,7 +99,7 @@ function MatchTermAnswer({ questionId, quizTakeChildren }: MatchTermAnswerProps)
                                                     <p className="font-semibold text-lg text-foreground">Točan odgovor:</p>
                                                     <div className="flex items-center space-x-3 p-4 border-2 border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-900/20 rounded-lg">
                                                         <span className="text-base font-medium text-green-700 dark:text-green-300">
-                                                            {correctAnswer.text}
+                                                            {correctAnswer?.text}
                                                         </span>
                                                         <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
                                                     </div>
@@ -134,7 +118,7 @@ function MatchTermAnswer({ questionId, quizTakeChildren }: MatchTermAnswerProps)
                                         <p className="font-semibold text-lg text-foreground">Točan odgovor:</p>
                                         <div className="flex items-center space-x-3 p-4 border-2 border-green-300 bg-green-50 dark:border-green-700 dark:bg-green-900/20 rounded-lg">
                                             <span className="text-base font-medium text-green-700 dark:text-green-300">
-                                                {correctAnswer.text}
+                                                {correctAnswer?.text}
                                             </span>
                                             <CheckCircle className="h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" />
                                         </div>

--- a/components/TakeQuiz/MakeMatchQuestion.tsx
+++ b/components/TakeQuiz/MakeMatchQuestion.tsx
@@ -3,14 +3,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Link } from "lucide-react";
 import { useEffect, useState } from 'react';
 
-import QuestionHeader from '../reusable/QuestionHeader';
+import { MatchAnswerSubmission } from '@/repositories/QuizRepository';
 
-interface QuizTakeAnswerDto {
-    questionId: number;
-    answerId: number;
-    parentId?: number;
-    text: string;
-}
+import QuestionHeader from '../reusable/QuestionHeader';
 
 interface Answer {
     id: number;
@@ -31,13 +26,13 @@ interface MakeMatchQuestionProps {
     question: Question;
     questionIndex: number;
     questionCount: number;
-    onAnswer: (questionId: number, answer: QuizTakeAnswerDto[]) => void;
-    initialAnswer?: QuizTakeAnswerDto[];
+    onAnswer: (questionId: number, answer: MatchAnswerSubmission[]) => void;
+    initialAnswer?: MatchAnswerSubmission[];
 }
 
 function MakeMatchQuestion({ question, questionIndex, questionCount, onAnswer, initialAnswer }: MakeMatchQuestionProps) {
     const [possibleAnswers, setPossibleAnswers] = useState<Answer[]>([]);
-    const [selectedAnswers, setSelectedAnswers] = useState<QuizTakeAnswerDto[]>([]);
+    const [selectedAnswers, setSelectedAnswers] = useState<MatchAnswerSubmission[]>([]);
 
     useEffect(() => {
         const answers = question.children?.map((child) => child.answers).flat() || [];
@@ -49,7 +44,7 @@ function MakeMatchQuestion({ question, questionIndex, questionCount, onAnswer, i
     }, [question, initialAnswer]);
 
     const handleSelectChange = (childId: number, answerId: string) => {
-        const answer: QuizTakeAnswerDto = {
+        const answer: MatchAnswerSubmission = {
             questionId: childId,
             answerId: parseInt(answerId),
             parentId: question.id,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build-analyze": "cross-env ANALYZE=true pnpm build",
     "export": "rimraf ./out && rimraf ./.next && cross-env NODE_ENV=production next build && next export",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "tsc --project tsconfig.test.json && node --test --require ./tests/register-paths.cjs \".test-dist/repositories/__tests__/**/*.test.js\""
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/repositories/QuizRepository.ts
+++ b/repositories/QuizRepository.ts
@@ -168,7 +168,7 @@ export async function getMatchTermQuestionAnswers(cityAssociationId: number, par
         const answersList = (answersResponse.data.list ?? []).map((answerDto: any) => mapMatchAnswer(answerDto));
 
         const question = mapMatchQuestion(childQuestionDto);
-        const correctAnswer = answersList.length > 0 ? answersList[0] : null;
+        const correctAnswer = answersList.find((answer) => answer.isCorrect) ?? (answersList.length > 0 ? answersList[0] : null);
 
         items.push({
             question,

--- a/repositories/QuizRepository.ts
+++ b/repositories/QuizRepository.ts
@@ -1,0 +1,183 @@
+import { Answer as MatchAnswer, Question as MatchQuestion } from '@/component-models/types';
+import { get, post } from '@/services/HttpService';
+
+export interface QuizAnswerOption {
+    id: number;
+    text: string;
+    questionId: number;
+}
+
+export interface QuizQuestionDetail {
+    id: number;
+    text: string;
+    questionType: number;
+    parentId: number | null;
+    children: QuizQuestionDetail[];
+    answers: QuizAnswerOption[];
+}
+
+export interface QuizDetail {
+    questions: QuizQuestionDetail[];
+}
+
+export interface MatchAnswerSubmission {
+    questionId: number;
+    answerId: number;
+    parentId?: number | null;
+    parentQuestionId?: number | null;
+    text: string;
+}
+
+export type QuizAnswerSelection = QuizAnswerOption | QuizAnswerOption[] | MatchAnswerSubmission[];
+
+export type QuizAnswersState = Record<number, QuizAnswerSelection>;
+
+export interface SubmitQuizTakeParams {
+    quizId: number;
+    questions: QuizQuestionDetail[];
+    answers: QuizAnswersState;
+    startedAt?: Date;
+    endedAt: Date;
+    takeUserName: string;
+    takeUserType: number;
+    cityAssociationId: number;
+}
+
+export interface MatchTermQuestionAnswers {
+    question: MatchQuestion;
+    correctAnswer: MatchAnswer | null;
+    answers: MatchAnswer[];
+}
+
+export interface MatchTermAnswersResult {
+    items: MatchTermQuestionAnswers[];
+}
+
+function mapQuizAnswerOption(dto: any): QuizAnswerOption {
+    return {
+        id: dto.id,
+        text: dto.text,
+        questionId: dto.questionId
+    };
+}
+
+function mapQuizQuestionDetail(dto: any): QuizQuestionDetail {
+    return {
+        id: dto.id,
+        text: dto.text,
+        questionType: dto.questionType,
+        parentId: dto.parentId ?? null,
+        children: (dto.children ?? []).map((child: any) => mapQuizQuestionDetail(child)),
+        answers: (dto.answers ?? []).map((answer: any) => mapQuizAnswerOption(answer))
+    };
+}
+
+function mapMatchQuestion(dto: any): MatchQuestion {
+    return {
+        id: dto.id,
+        text: dto.text
+    };
+}
+
+function mapMatchAnswer(dto: any): MatchAnswer {
+    return {
+        id: dto.id,
+        text: dto.text,
+        questionId: dto.questionId,
+        isCorrect: Boolean(dto.isCorrect)
+    };
+}
+
+function mapQuizDetail(dto: any): QuizDetail {
+    return {
+        questions: (dto.questions ?? []).map((question: any) => mapQuizQuestionDetail(question))
+    };
+}
+
+export async function initializeQuiz(payload: { quizCategoryId: number | null; quizTheme: number | null; cityAssociationId: number; }): Promise<number> {
+    const requestBody = {
+        QuizCategoryId: payload.quizCategoryId,
+        QuizTheme: payload.quizTheme,
+        CityAssociationId: payload.cityAssociationId
+    };
+
+    const response = await post('quizzes/PublicQuiz', requestBody);
+    return response.data;
+}
+
+export async function getQuizDetail(quizId: number): Promise<QuizDetail> {
+    const response = await get(`quizzes/PublicQuiz/GetDetail/${quizId}`);
+    return mapQuizDetail(response.data);
+}
+
+export async function submitQuizTake(params: SubmitQuizTakeParams): Promise<number> {
+    const questionDtos = params.questions.map((question, index) => {
+        const storedAnswer = params.answers[question.id];
+        let mappedAnswers: MatchAnswerSubmission[] = [];
+
+        if (question.questionType === 4) {
+            mappedAnswers = Array.isArray(storedAnswer) ? storedAnswer as MatchAnswerSubmission[] : [];
+        } else if (Array.isArray(storedAnswer)) {
+            mappedAnswers = (storedAnswer as QuizAnswerOption[]).map((answer) => ({
+                questionId: question.id,
+                answerId: answer.id,
+                text: answer.text,
+                parentQuestionId: question.parentId ?? undefined
+            }));
+        } else if (storedAnswer) {
+            const answer = storedAnswer as QuizAnswerOption;
+            mappedAnswers = [{
+                questionId: question.id,
+                answerId: answer.id,
+                text: answer.text,
+                parentQuestionId: question.parentId ?? undefined
+            }];
+        }
+
+        return {
+            id: 0,
+            questionId: question.id,
+            index,
+            parentId: question.parentId ?? undefined,
+            answers: mappedAnswers
+        };
+    });
+
+    const requestBody = {
+        quizId: params.quizId,
+        startedAt: params.startedAt ?? null,
+        endedAt: params.endedAt,
+        takeUserName: params.takeUserName,
+        takeUserType: params.takeUserType,
+        questions: questionDtos,
+        cityAssociationId: params.cityAssociationId
+    };
+
+    const response = await post('quizzes/PublicQuizTake', requestBody);
+    return response.data;
+}
+
+export async function getMatchTermQuestionAnswers(cityAssociationId: number, parentQuestionId: number): Promise<MatchTermAnswersResult> {
+    const childQuestionsResponse = await get(`Quizzes/PublicQuestion/getList/${cityAssociationId}?parentId=${parentQuestionId}&ActiveStatusId=0&QuizCategoryId=0&QuizId=0&QuizTheme=None&QuestionType=None&Page=0&SearchTerm=&Type=&Field=&IgnorePageSize=True&PerPage=10`);
+    const childQuestions = childQuestionsResponse.data.list ?? [];
+
+    const items: MatchTermQuestionAnswers[] = [];
+
+    for (const childQuestionDto of childQuestions) {
+        const answersResponse = await get(`Quizzes/PublicAnswer/GetList?questionId=${childQuestionDto.id}&Page=0&SearchTerm=&Type=&Field=&IgnorePageSize=False&PerPage=10`);
+        const answersList = (answersResponse.data.list ?? []).map((answerDto: any) => mapMatchAnswer(answerDto));
+
+        const question = mapMatchQuestion(childQuestionDto);
+        const correctAnswer = answersList.length > 0 ? answersList[0] : null;
+
+        items.push({
+            question,
+            correctAnswer,
+            answers: answersList
+        });
+    }
+
+    return { items };
+}
+
+export type { QuizAnswerOption as QuizViewAnswerOption };

--- a/repositories/__tests__/QuizRepository.test.ts
+++ b/repositories/__tests__/QuizRepository.test.ts
@@ -175,8 +175,8 @@ describe('QuizRepository', () => {
             if (callIndex === 1) {
                 callIndex++;
                 return { data: { list: [
-                    { id: 100, text: 'Answer A', questionId: 10, isCorrect: true },
-                    { id: 101, text: 'Answer B', questionId: 10, isCorrect: false }
+                    { id: 100, text: 'Answer A', questionId: 10, isCorrect: false },
+                    { id: 101, text: 'Answer B', questionId: 10, isCorrect: true }
                 ] } } as any;
             }
             if (callIndex === 2) {
@@ -191,7 +191,7 @@ describe('QuizRepository', () => {
         const result = await getMatchTermQuestionAnswers(5, 99);
 
         assert.equal(result.items.length, 2);
-        assert.equal(result.items[0].correctAnswer?.id, 100);
+        assert.equal(result.items[0].correctAnswer?.id, 101);
         assert.equal(result.items[1].answers[0].isCorrect, true);
         assert.equal(getMock.mock.callCount(), 3);
     });

--- a/repositories/__tests__/QuizRepository.test.ts
+++ b/repositories/__tests__/QuizRepository.test.ts
@@ -1,0 +1,219 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+import * as HttpService from '../../services/HttpService';
+import {
+    getMatchTermQuestionAnswers,
+    getQuizDetail,
+    initializeQuiz,
+    MatchAnswerSubmission,
+    QuizAnswerOption,
+    QuizAnswersState,
+    QuizQuestionDetail,
+    submitQuizTake
+} from '../QuizRepository';
+
+afterEach(() => {
+    mock.restoreAll();
+});
+
+describe('QuizRepository', () => {
+    it('maps quiz detail responses into typed questions', async () => {
+        const getMock = mock.method(HttpService, 'get');
+        getMock.mock.mockImplementationOnce(async () => ({
+            data: {
+                questions: [
+                    {
+                        id: 1,
+                        text: 'Root question',
+                        questionType: 1,
+                        parentId: null,
+                        answers: [
+                            { id: 11, text: 'Answer', questionId: 1 }
+                        ],
+                        children: [
+                            {
+                                id: 2,
+                                text: 'Child question',
+                                questionType: 4,
+                                parentId: 1,
+                                answers: [
+                                    { id: 21, text: 'Child answer', questionId: 2 }
+                                ],
+                                children: []
+                            }
+                        ]
+                    }
+                ]
+            }
+        }) as any);
+
+        const result = await getQuizDetail(7);
+
+        assert.equal(getMock.mock.callCount(), 1);
+        assert.deepEqual(result.questions[0].answers[0], { id: 11, text: 'Answer', questionId: 1 } satisfies QuizAnswerOption);
+        assert.equal(result.questions[0].children[0].id, 2);
+    });
+
+    it('submits quiz take payload with mapped answers', async () => {
+        const postMock = mock.method(HttpService, 'post');
+        postMock.mock.mockImplementation(async (_url, body) => ({ data: 55, body } as any));
+
+        const questions: QuizQuestionDetail[] = [
+            {
+                id: 1,
+                text: 'Single choice',
+                questionType: 1,
+                parentId: null,
+                answers: [],
+                children: []
+            },
+            {
+                id: 2,
+                text: 'Multiple choice',
+                questionType: 2,
+                parentId: null,
+                answers: [],
+                children: []
+            },
+            {
+                id: 3,
+                text: 'Match',
+                questionType: 4,
+                parentId: null,
+                answers: [],
+                children: []
+            }
+        ];
+
+        const answers: QuizAnswersState = {
+            1: { id: 101, text: 'Single', questionId: 1 },
+            2: [
+                { id: 201, text: 'Multi A', questionId: 2 },
+                { id: 202, text: 'Multi B', questionId: 2 }
+            ],
+            3: [
+                { questionId: 31, answerId: 301, parentId: 3, text: 'Match A' } as MatchAnswerSubmission
+            ]
+        };
+
+        const submissionId = await submitQuizTake({
+            quizId: 99,
+            questions,
+            answers,
+            startedAt: new Date('2024-01-01T00:00:00Z'),
+            endedAt: new Date('2024-01-01T00:05:00Z'),
+            takeUserName: 'John Doe',
+            takeUserType: 4,
+            cityAssociationId: 12
+        });
+
+        assert.equal(submissionId, 55);
+        const firstCall = postMock.mock.calls[0];
+        const [url, payload] = firstCall.arguments as [string, any];
+        assert.equal(url, 'quizzes/PublicQuizTake');
+        assert.deepEqual(payload.questions, [
+            {
+                id: 0,
+                questionId: 1,
+                index: 0,
+                parentId: undefined,
+                answers: [
+                    {
+                        questionId: 1,
+                        answerId: 101,
+                        text: 'Single',
+                        parentQuestionId: undefined
+                    }
+                ]
+            },
+            {
+                id: 0,
+                questionId: 2,
+                index: 1,
+                parentId: undefined,
+                answers: [
+                    {
+                        questionId: 2,
+                        answerId: 201,
+                        text: 'Multi A',
+                        parentQuestionId: undefined
+                    },
+                    {
+                        questionId: 2,
+                        answerId: 202,
+                        text: 'Multi B',
+                        parentQuestionId: undefined
+                    }
+                ]
+            },
+            {
+                id: 0,
+                questionId: 3,
+                index: 2,
+                parentId: undefined,
+                answers: [
+                    {
+                        questionId: 31,
+                        answerId: 301,
+                        parentId: 3,
+                        text: 'Match A'
+                    }
+                ]
+            }
+        ]);
+    });
+
+    it('fetches match term answers for child questions', async () => {
+        const getMock = mock.method(HttpService, 'get');
+        let callIndex = 0;
+        getMock.mock.mockImplementation(async () => {
+            if (callIndex === 0) {
+                callIndex++;
+                return { data: { list: [{ id: 10, text: 'Child A' }, { id: 11, text: 'Child B' }] } } as any;
+            }
+            if (callIndex === 1) {
+                callIndex++;
+                return { data: { list: [
+                    { id: 100, text: 'Answer A', questionId: 10, isCorrect: true },
+                    { id: 101, text: 'Answer B', questionId: 10, isCorrect: false }
+                ] } } as any;
+            }
+            if (callIndex === 2) {
+                callIndex++;
+                return { data: { list: [
+                    { id: 200, text: 'Answer C', questionId: 11, isCorrect: true }
+                ] } } as any;
+            }
+            throw new Error('Unexpected get call');
+        });
+
+        const result = await getMatchTermQuestionAnswers(5, 99);
+
+        assert.equal(result.items.length, 2);
+        assert.equal(result.items[0].correctAnswer?.id, 100);
+        assert.equal(result.items[1].answers[0].isCorrect, true);
+        assert.equal(getMock.mock.callCount(), 3);
+    });
+
+    it('initializes quiz with expected payload', async () => {
+        const postMock = mock.method(HttpService, 'post');
+        postMock.mock.mockImplementation(async () => ({ data: 777 } as any));
+
+        const result = await initializeQuiz({
+            quizCategoryId: 3,
+            quizTheme: 4,
+            cityAssociationId: 15
+        });
+
+        assert.equal(result, 777);
+        const initCall = postMock.mock.calls[0];
+        const [initUrl, initPayload] = initCall.arguments as [string, any];
+        assert.equal(initUrl, 'quizzes/PublicQuiz');
+        assert.deepEqual(initPayload, {
+            QuizCategoryId: 3,
+            QuizTheme: 4,
+            CityAssociationId: 15
+        });
+    });
+});

--- a/tests/register-paths.cjs
+++ b/tests/register-paths.cjs
@@ -1,0 +1,13 @@
+const Module = require('module');
+const path = require('path');
+
+const baseDir = path.resolve(__dirname, '..', '.test-dist');
+const originalResolve = Module._resolveFilename;
+
+Module._resolveFilename = function(request, parent, isMain, options) {
+    if (request.startsWith('@/')) {
+        const resolved = path.join(baseDir, request.slice(2));
+        return originalResolve.call(this, resolved, parent, isMain, options);
+    }
+    return originalResolve.call(this, request, parent, isMain, options);
+};

--- a/tests/types/node/index.d.ts
+++ b/tests/types/node/index.d.ts
@@ -1,0 +1,39 @@
+declare module 'node:assert/strict' {
+    const assert: {
+        equal(actual: unknown, expected: unknown, message?: string): void;
+        deepEqual(actual: unknown, expected: unknown, message?: string): void;
+    };
+    export default assert;
+}
+
+declare module 'node:test' {
+    type TestFunction = () => void | Promise<void>;
+    export function describe(name: string, fn: TestFunction): void;
+    export function it(name: string, fn: TestFunction): void;
+    export function afterEach(fn: TestFunction): void;
+    export const mock: {
+        method<T extends object, K extends keyof T>(target: T, key: K): {
+            mock: {
+                callCount(): number;
+                calls: Array<any>;
+                mockImplementation(impl: T[K] extends (...args: any[]) => any ? T[K] : (...args: any[]) => any): void;
+                mockImplementationOnce(impl: T[K] extends (...args: any[]) => any ? T[K] : (...args: any[]) => any): void;
+                restore(): void;
+            };
+        };
+        fn<T extends (...args: any[]) => any>(impl?: T): T & {
+            mock: {
+                callCount(): number;
+                calls: Array<any>;
+                mockImplementation(implementation: T): void;
+                mockImplementationOnce(implementation: T): void;
+                restore(): void;
+            };
+        };
+        restoreAll(): void;
+    };
+}
+
+declare const process: {
+    env: Record<string, string | undefined>;
+};

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": ".test-dist",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "target": "ES2020",
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "typeRoots": ["./tests/types"]
+  },
+  "include": [
+    "component-models/**/*.ts",
+    "services/**/*.ts",
+    "config/**/*.ts",
+    "repositories/QuizRepository.ts",
+    "repositories/__tests__/**/*.ts"
+  ]
+}

--- a/views/InitQuizView/InitQuizView.tsx
+++ b/views/InitQuizView/InitQuizView.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 
 import { useConfig } from '@/components/providers/ConfigProvider';
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { post } from '../../services/HttpService';
+import { initializeQuiz } from '@/repositories/QuizRepository';
 
 export default function InitQuizView() {
     const router = useRouter();
@@ -20,14 +20,15 @@ export default function InitQuizView() {
     useEffect(() => {
         const initializeQuiz = async () => {
             try {
-                const data = {
-                    QuizCategoryId: category ? parseInt(category) : null,
-                    QuizTheme: theme ? parseInt(theme) : null,
-                    CityAssociationId: config.cityAssociationId
-                };
+                const quizCategoryId = category ? parseInt(category) : null;
+                const quizTheme = theme ? parseInt(theme) : null;
 
-                const response = await post('quizzes/PublicQuiz', data);
-                setQuizId(response.data);
+                const quizIdentifier = await initializeQuiz({
+                    quizCategoryId,
+                    quizTheme,
+                    cityAssociationId: config.cityAssociationId
+                });
+                setQuizId(quizIdentifier);
             } catch (error) {
                 console.error('Error initializing quiz:', error);
             } finally {
@@ -38,7 +39,7 @@ export default function InitQuizView() {
         if (theme && category) {
             initializeQuiz();
         }
-    }, [theme, category]);
+    }, [theme, category, config.cityAssociationId]);
 
     const handleStartQuiz = () => {
         if (quizId) {

--- a/views/InitQuizView/InitQuizView.tsx
+++ b/views/InitQuizView/InitQuizView.tsx
@@ -18,7 +18,7 @@ export default function InitQuizView() {
     const [loading, setLoading] = useState<boolean>(true);
 
     useEffect(() => {
-        const initializeQuiz = async () => {
+        const runInitializeQuiz = async () => {
             try {
                 const quizCategoryId = category ? parseInt(category) : null;
                 const quizTheme = theme ? parseInt(theme) : null;
@@ -37,7 +37,7 @@ export default function InitQuizView() {
         };
 
         if (theme && category) {
-            initializeQuiz();
+            runInitializeQuiz();
         }
     }, [theme, category, config.cityAssociationId]);
 

--- a/views/QuizView/QuizView.tsx
+++ b/views/QuizView/QuizView.tsx
@@ -12,42 +12,7 @@ import UserInfo from '@/components/TakeQuiz/UserInfo';
 
 import { useConfig } from '@/components/providers/ConfigProvider';
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { get, post } from '../../services/HttpService';
-
-interface QuizTakeQuestionDto {
-    id: number;
-    questionId: number;
-    index: number;
-    parentId?: number | null;
-    answers: QuizTakeAnswerDto[];
-}
-
-
-interface QuizTakeAnswerDto {
-    questionId: number;
-    answerId: number;
-    parentId?: number;
-    text: string;
-}
-
-interface Answer {
-    id: number;
-    text: string;
-    questionId: number;
-}
-
-interface Question {
-    id: number;
-    text: string;
-    questionType: number;
-    parentId: number | null;
-    children: Question[] | null;
-    answers: Answer[];
-}
-
-interface QuizDetail {
-    questions: Question[];
-}
+import { getQuizDetail, MatchAnswerSubmission, QuizAnswerOption, QuizAnswersState, QuizDetail, submitQuizTake } from '@/repositories/QuizRepository';
 
 export default function QuizView() {
     const router = useRouter();
@@ -58,7 +23,7 @@ export default function QuizView() {
     const [quiz, setQuiz] = useState<QuizDetail | null>(null);
     const [currentQuestionIndex, setCurrentQuestionIndex] = useState<number>(0);
     const [loading, setLoading] = useState<boolean>(true);
-    const [answers, setAnswers] = useState<any>({});
+    const [answers, setAnswers] = useState<QuizAnswersState>({});
     const [enablePrevious, setEnablePrevious] = useState<boolean>(false);
     const [enableNext, setEnableNext] = useState<boolean>(false);
     const [startedAt, setStartedAt] = useState<Date>();
@@ -66,8 +31,8 @@ export default function QuizView() {
     useEffect(() => {
         const fetchQuizDetails = async () => {
             try {
-                const response = await get(`quizzes/PublicQuiz/GetDetail/${quizId}`);
-                setQuiz(response.data);
+                const quizDetail = await getQuizDetail(parseInt(quizId));
+                setQuiz(quizDetail);
             } catch (error) {
                 console.error('Error fetching quiz details:', error);
             } finally {
@@ -116,7 +81,7 @@ export default function QuizView() {
         router.back();
     };
 
-    const handleSingleAnswer = (questionId: number, answer: Answer) => {
+    const handleSingleAnswer = (questionId: number, answer: QuizAnswerOption) => {
         setEnableNext(true);
         const updatedAnswers = {
             ...answers,
@@ -125,7 +90,7 @@ export default function QuizView() {
         setAnswers(updatedAnswers);
     };
 
-    const handleMultipleAnswer = (questionId: number, givenAnswers: Answer[]) => {
+    const handleMultipleAnswer = (questionId: number, givenAnswers: QuizAnswerOption[]) => {
         setEnableNext(true);
         const updatedAnswers = {
             ...answers,
@@ -136,7 +101,7 @@ export default function QuizView() {
 
     const handleTextAnswer = (questionId: number, answerText: string) => {
         setEnableNext(true);
-        const answer = {
+        const answer: QuizAnswerOption = {
             id: 0,
             text: answerText,
             questionId: questionId
@@ -148,7 +113,7 @@ export default function QuizView() {
         setAnswers(updatedAnswers);
     };
 
-    const handleAnswer = (questionId: number, answer: QuizTakeAnswerDto[]) => {
+    const handleAnswer = (questionId: number, answer: MatchAnswerSubmission[]) => {
         setEnableNext(true);
         const updatedAnswers = {
             ...answers,
@@ -158,51 +123,21 @@ export default function QuizView() {
     };
 
     const submitQuiz = async (name: string, role: string) => {
-        const quizTakeDto = {
-            quizId: parseInt(quizId!),
-            startedAt: startedAt,
+        if (!quizId || !quiz) {
+            return;
+        }
+
+        const submissionId = await submitQuizTake({
+            quizId: parseInt(quizId),
+            questions: quiz.questions,
+            answers,
+            startedAt,
             endedAt: new Date(),
             takeUserName: name,
             takeUserType: parseInt(role),
-            questions: Object.keys(quiz.questions).map((key, index) => {
-                const question = quiz.questions[key];
-                let questionAnswers = [];
-                if (question.questionType === 4) {
-                    questionAnswers = answers[question.id];
-                }
-                else {
-                    if (Array.isArray(answers[question.id])) {
-                        questionAnswers = answers[question.id].map((answer: Answer) => {
-                            return {
-                                questionId: question.id,
-                                answerId: answer.id,
-                                text: answer.text,
-                                parentQuestionId: question.parentId
-                            };
-                        });
-                    }
-                    else {
-                        questionAnswers = [{
-                            questionId: question.id,
-                            answerId: answers[question.id].id,
-                            text: answers[question.id].text,
-                            parentQuestionId: question.parentId
-                        }];
-                    }
-                }
-                const quizTakeQuestionDto: QuizTakeQuestionDto = {
-                    id: 0,
-                    questionId: question.id,
-                    index: index,
-                    parentId: question.parentId,
-                    answers: questionAnswers
-                };
-                return quizTakeQuestionDto;
-            }),
             cityAssociationId: config.cityAssociationId
-        };
-        const response = await post('quizzes/PublicQuizTake', quizTakeDto);
-        router.push(`/result?take-id=${response.data}`);
+        });
+        router.push(`/result?take-id=${submissionId}`);
     };
 
 


### PR DESCRIPTION
## Summary
- add a QuizRepository that shapes quiz detail, submission, and match-term responses
- refactor quiz screens/components to consume the repository instead of HttpService directly
- wire up node:test configuration and mocks to cover the new repository methods

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e299bfad4c8320bf54665a195891a9