### PR TITLE
Refactor quiz models to share DTO definitions

### DIFF
--- a/component-models/types.tsx
+++ b/component-models/types.tsx
@@ -1,9 +1,15 @@
-// MatchTermAnswer.tsx
+export enum QuestionType {
+    SingleChoice = 1,
+    MultipleChoice = 2,
+    TextInput = 3,
+    MatchTerms = 4
+}
+
 export interface Answer {
     id: number;
     text: string;
     questionId: number;
-    isCorrect: boolean;
+    isCorrect?: boolean;
 }
 
 export interface Question {
@@ -11,17 +17,57 @@ export interface Question {
     text: string;
 }
 
+export interface QuizAnswerOption {
+    id: number;
+    text: string;
+    questionId: number;
+}
+
+export interface QuizQuestionDetail {
+    id: number;
+    text: string;
+    questionType: QuestionType;
+    parentId: number | null;
+    children: QuizQuestionDetail[];
+    answers: QuizAnswerOption[];
+}
+
+export interface QuizDetail {
+    questions: QuizQuestionDetail[];
+}
+
+export interface QuizTakeAnswerDto {
+    questionId: number;
+    answerId: number;
+    text: string;
+    parentId?: number | null;
+    parentQuestionId?: number | null;
+}
+
+export type QuizAnswerSelection =
+    | QuizAnswerOption
+    | QuizAnswerOption[]
+    | QuizTakeAnswerDto[];
+
+export type QuizAnswersState = Record<number, QuizAnswerSelection | undefined>;
+
+export interface SubmitQuizTakeParams {
+    quizId: number;
+    questions: QuizQuestionDetail[];
+    answers: QuizAnswersState;
+    startedAt?: Date;
+    endedAt: Date;
+    takeUserName: string;
+    takeUserType: number;
+    cityAssociationId: number;
+}
+
 export interface QuizTakeQuestion {
     questionId: number;
     answers: Answer[];
 }
 
-// page.tsx (take-result)
-export interface QuizTakeDetailViewModel extends QuizTakeViewModel {
-    quizTakeQuestions: QuizTakeQuestionViewModel[];
-}
-
-interface QuizTakeViewModel {
+export interface QuizTakeViewModel {
     id: number;
     quizId: number;
     quizTitle: string;
@@ -33,7 +79,7 @@ interface QuizTakeViewModel {
     takeUserType: string;
 }
 
-interface QuizTakeQuestionViewModel {
+export interface QuizTakeQuestionViewModel {
     id: number;
     questionId: number;
     text: string;
@@ -41,14 +87,36 @@ interface QuizTakeQuestionViewModel {
     parentId?: number | null;
     isCorrect: boolean;
     children: QuizTakeQuestionViewModel[];
-    questionType: number;
+    questionType: QuestionType;
     answers: Answer[];
 }
 
-export type QuizCategory = {
+export interface QuizTakeDetailViewModel extends QuizTakeViewModel {
+    quizTakeQuestions: QuizTakeQuestionViewModel[];
+}
+
+export interface QuizTakeQuestionSubmissionDto {
+    id: number;
+    questionId: number;
+    index: number;
+    parentId?: number | null;
+    answers: QuizTakeAnswerDto[];
+}
+
+export interface QuizCategory {
     id: number;
     name: string;
     isActiveDescription: string;
     quizTheme: number;
     description: string | null;
-  }
+}
+
+export interface MatchTermQuestionAnswers {
+    question: Question;
+    correctAnswer: Answer | null;
+    answers: Answer[];
+}
+
+export interface MatchTermAnswersResult {
+    items: MatchTermQuestionAnswers[];
+}

--- a/components/TakeAnswer/MatchTermAnswer.tsx
+++ b/components/TakeAnswer/MatchTermAnswer.tsx
@@ -3,8 +3,8 @@
 import { CheckCircle, X, XCircle } from "lucide-react";
 import { useEffect, useMemo, useState } from 'react';
 
-import { Answer, QuizTakeQuestion } from '@/component-models/types';
-import { getMatchTermQuestionAnswers, MatchTermQuestionAnswers } from '@/repositories/QuizRepository';
+import { Answer, MatchTermQuestionAnswers, QuizTakeQuestion } from '@/component-models/types';
+import { getMatchTermQuestionAnswers } from '@/repositories/QuizRepository';
 import { useConfig } from "../providers/ConfigProvider";
 
 interface MatchTermAnswerProps {

--- a/components/TakeQuiz/ChooseManyQuestion.tsx
+++ b/components/TakeQuiz/ChooseManyQuestion.tsx
@@ -3,28 +3,20 @@ import { Label } from "@/components/ui/label";
 import { Check } from "lucide-react";
 import React, { useEffect } from 'react';
 
+import { QuizAnswerOption, QuizQuestionDetail } from '@/component-models/types';
+
 import QuestionHeader from '../reusable/QuestionHeader';
 
-interface Answer {
-    id: number;
-    text: string;
-    questionId: number;
-}
-
 interface ChooseManyQuestionProps {
-    question: {
-        id: number;
-        text: string;
-        answers: Answer[];
-    };
+    question: Pick<QuizQuestionDetail, 'id' | 'text' | 'answers'>;
     questionIndex: number;
     questionCount: number;
-    onAnswer: (questionId: number, answers: Answer[]) => void;
-    initialAnswers?: Answer[];
+    onAnswer: (questionId: number, answers: QuizAnswerOption[]) => void;
+    initialAnswers?: QuizAnswerOption[];
 }
 
 function ChooseManyQuestion({ question, questionIndex, questionCount, onAnswer, initialAnswers }: ChooseManyQuestionProps) {
-    const [selectedAnswers, setSelectedAnswers] = React.useState<Answer[]>([]);
+    const [selectedAnswers, setSelectedAnswers] = React.useState<QuizAnswerOption[]>([]);
 
     useEffect(() => {
         if (initialAnswers) {

--- a/components/TakeQuiz/ChooseOneQuestion.tsx
+++ b/components/TakeQuiz/ChooseOneQuestion.tsx
@@ -2,24 +2,16 @@ import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useEffect, useState } from 'react';
 
+import { QuizAnswerOption, QuizQuestionDetail } from '@/component-models/types';
+
 import QuestionHeader from '../reusable/QuestionHeader';
 
-interface Answer {
-    id: number;
-    text: string;
-    questionId: number;
-}
-
 interface ChooseOneQuestionProps {
-    question: {
-        id: number;
-        text: string;
-        answers: Answer[];
-    };
+    question: Pick<QuizQuestionDetail, 'id' | 'text' | 'answers'>;
     questionIndex: number;
     questionCount: number;
-    onAnswer: (questionId: number, answer: Answer) => void;
-    initialAnswers?: Answer[];
+    onAnswer: (questionId: number, answer: QuizAnswerOption) => void;
+    initialAnswers?: QuizAnswerOption[];
 }
 
 function ChooseOneQuestion({ question, questionIndex, questionCount, onAnswer, initialAnswers }: ChooseOneQuestionProps) {

--- a/components/TakeQuiz/MakeMatchQuestion.tsx
+++ b/components/TakeQuiz/MakeMatchQuestion.tsx
@@ -3,39 +3,24 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Link } from "lucide-react";
 import { useEffect, useState } from 'react';
 
-import { MatchAnswerSubmission } from '@/repositories/QuizRepository';
+import { QuizAnswerOption, QuizQuestionDetail, QuizTakeAnswerDto } from '@/component-models/types';
 
 import QuestionHeader from '../reusable/QuestionHeader';
 
-interface Answer {
-    id: number;
-    text: string;
-    questionId: number;
-}
-
-interface Question {
-    id: number;
-    text: string;
-    questionType: number;
-    parentId: number | null;
-    children: Question[] | null;
-    answers: Answer[];
-}
-
 interface MakeMatchQuestionProps {
-    question: Question;
+    question: QuizQuestionDetail;
     questionIndex: number;
     questionCount: number;
-    onAnswer: (questionId: number, answer: MatchAnswerSubmission[]) => void;
-    initialAnswer?: MatchAnswerSubmission[];
+    onAnswer: (questionId: number, answer: QuizTakeAnswerDto[]) => void;
+    initialAnswer?: QuizTakeAnswerDto[];
 }
 
 function MakeMatchQuestion({ question, questionIndex, questionCount, onAnswer, initialAnswer }: MakeMatchQuestionProps) {
-    const [possibleAnswers, setPossibleAnswers] = useState<Answer[]>([]);
-    const [selectedAnswers, setSelectedAnswers] = useState<MatchAnswerSubmission[]>([]);
+    const [possibleAnswers, setPossibleAnswers] = useState<QuizAnswerOption[]>([]);
+    const [selectedAnswers, setSelectedAnswers] = useState<QuizTakeAnswerDto[]>([]);
 
     useEffect(() => {
-        const answers = question.children?.map((child) => child.answers).flat() || [];
+        const answers = (question.children ?? []).flatMap((child) => child.answers);
         setPossibleAnswers(answers);
 
         if (initialAnswer) {
@@ -44,11 +29,13 @@ function MakeMatchQuestion({ question, questionIndex, questionCount, onAnswer, i
     }, [question, initialAnswer]);
 
     const handleSelectChange = (childId: number, answerId: string) => {
-        const answer: MatchAnswerSubmission = {
+        const numericAnswerId = parseInt(answerId);
+        const selectedOption = possibleAnswers.find((option) => option.id === numericAnswerId);
+        const answer: QuizTakeAnswerDto = {
             questionId: childId,
-            answerId: parseInt(answerId),
+            answerId: numericAnswerId,
             parentId: question.id,
-            text: ''
+            text: selectedOption?.text ?? ''
         };
 
         const answersArray = [...selectedAnswers];

--- a/components/TakeQuiz/TypeAnswerQuestion.tsx
+++ b/components/TakeQuiz/TypeAnswerQuestion.tsx
@@ -2,13 +2,12 @@ import { Input } from "@/components/ui/input";
 import { PenTool } from "lucide-react";
 import React, { useEffect, useState } from 'react';
 
+import { QuizQuestionDetail } from '@/component-models/types';
+
 import QuestionHeader from '../reusable/QuestionHeader';
 
 interface TypeAnswerQuestionProps {
-    question: {
-        id: number;
-        text: string;
-    };
+    question: Pick<QuizQuestionDetail, 'id' | 'text'>;
     questionIndex: number;
     questionCount: number;
     onAnswer: (questionId: number, answer: string) => void;

--- a/repositories/__tests__/QuizRepository.test.ts
+++ b/repositories/__tests__/QuizRepository.test.ts
@@ -6,12 +6,14 @@ import {
     getMatchTermQuestionAnswers,
     getQuizDetail,
     initializeQuiz,
-    MatchAnswerSubmission,
+    submitQuizTake
+} from '../QuizRepository';
+import {
     QuizAnswerOption,
     QuizAnswersState,
     QuizQuestionDetail,
-    submitQuizTake
-} from '../QuizRepository';
+    QuizTakeAnswerDto
+} from '../../component-models/types';
 
 afterEach(() => {
     mock.restoreAll();
@@ -93,7 +95,7 @@ describe('QuizRepository', () => {
                 { id: 202, text: 'Multi B', questionId: 2 }
             ],
             3: [
-                { questionId: 31, answerId: 301, parentId: 3, text: 'Match A' } as MatchAnswerSubmission
+                { questionId: 31, answerId: 301, parentId: 3, text: 'Match A' } as QuizTakeAnswerDto
             ]
         };
 

--- a/views/QuizView/QuizView.tsx
+++ b/views/QuizView/QuizView.tsx
@@ -12,7 +12,8 @@ import UserInfo from '@/components/TakeQuiz/UserInfo';
 
 import { useConfig } from '@/components/providers/ConfigProvider';
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
-import { getQuizDetail, MatchAnswerSubmission, QuizAnswerOption, QuizAnswersState, QuizDetail, submitQuizTake } from '@/repositories/QuizRepository';
+import { QuizAnswerOption, QuizAnswersState, QuizDetail, QuizTakeAnswerDto } from '@/component-models/types';
+import { getQuizDetail, submitQuizTake } from '@/repositories/QuizRepository';
 
 export default function QuizView() {
     const router = useRouter();
@@ -113,7 +114,7 @@ export default function QuizView() {
         setAnswers(updatedAnswers);
     };
 
-    const handleAnswer = (questionId: number, answer: MatchAnswerSubmission[]) => {
+    const handleAnswer = (questionId: number, answer: QuizTakeAnswerDto[]) => {
         setEnableNext(true);
         const updatedAnswers = {
             ...answers,


### PR DESCRIPTION
## Summary
- consolidate quiz/question/answer DTOs in `component-models/types.tsx`
- refactor quiz view, take components, and repository logic to consume the shared models
- align submission mapping/tests with `QuizTakeAnswerDto` and centralized state types

## Testing
- pnpm exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e2a533fab48320a18f8e134da7aee4