### PR TITLE
Align finish quiz button sizing with shared styles

### DIFF
--- a/components/TakeQuiz/UserInfo.tsx
+++ b/components/TakeQuiz/UserInfo.tsx
@@ -97,7 +97,7 @@ function UserInfo({ onSubmit, onBack }: UserInfoProps) {
                     onClick={handleSubmit}
                     disabled={!userName || !role}
                     size="lg"
-                    className="w-full sm:w-auto text-lg py-6 md:py-3 sm:text-sm bg-red-600 hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600 text-white font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="w-full sm:w-auto bg-red-600 hover:bg-red-700 dark:bg-red-500 dark:hover:bg-red-600 text-white font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                     <CheckCircle className="h-5 w-5 mr-2" />
                     Završi kviz


### PR DESCRIPTION
## Summary
- update the finish quiz button to use the shared large size styling so its height and typography match other primary actions

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e2b1ed57208320a12a0d5f4460362a