### PR TITLE
Wrap user info form in card components

### DIFF
--- a/components/TakeQuiz/UserInfo.tsx
+++ b/components/TakeQuiz/UserInfo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -8,7 +9,7 @@ import { ArrowLeft, CheckCircle, User, Users } from "lucide-react";
 import { useState } from 'react';
 
 interface UserInfoProps {
-    onSubmit: (name, role) => void;
+    onSubmit: (name: string, role: string) => void;
     onBack: () => void;
 }
 
@@ -17,6 +18,10 @@ function UserInfo({ onSubmit, onBack }: UserInfoProps) {
     const [role, setRole] = useState<string | null>(null);
 
     const handleSubmit = async () => {
+        if (!role) {
+            return;
+        }
+
         onSubmit(userName, role);
     };
 
@@ -25,64 +30,65 @@ function UserInfo({ onSubmit, onBack }: UserInfoProps) {
     };
 
     return (
-        <div className="space-y-8">
-            {/* Header */}
-            <div className="text-center space-y-4">
-                <div className="inline-flex items-center justify-center w-16 h-16 bg-primary-100 dark:bg-primary-900 rounded-full mb-4">
-                    <User className="h-8 w-8 text-red-600 dark:text-red-400" />
+        <Card>
+            <CardContent className="space-y-8">
+                {/* Header */}
+                <div className="text-center space-y-4">
+                    <div className="inline-flex items-center justify-center w-16 h-16 bg-primary-100 dark:bg-primary-900 rounded-full mb-4">
+                        <User className="h-8 w-8 text-red-600 dark:text-red-400" />
+                    </div>
+                    <h2 className="text-3xl font-bold text-primary-600 dark:text-primary-400">
+                        Gotov si!
+                    </h2>
+                    <p className="text-lg text-muted-foreground max-w-md mx-auto">
+                        Unesite svoje podatke da biste vidjeli rezultat kviza
+                    </p>
                 </div>
-                <h2 className="text-3xl font-bold text-primary-600 dark:text-primary-400">
-                    Gotov si!
-                </h2>
-                <p className="text-lg text-muted-foreground max-w-md mx-auto">
-                    Unesite svoje podatke da biste vidjeli rezultat kviza
-                </p>
-            </div>
 
-            {/* Form */}
-            <div className="space-y-6">
-                <div className="space-y-3">
-                    <Label htmlFor="userName" className="text-lg font-medium text-foreground">
-                        Tvoje ime
-                    </Label>
-                    <div className="relative">
-                        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                            <User className="h-5 w-5 text-slate-400" />
+                {/* Form */}
+                <div className="space-y-6">
+                    <div className="space-y-3">
+                        <Label htmlFor="userName" className="text-lg font-medium text-foreground">
+                            Tvoje ime
+                        </Label>
+                        <div className="relative">
+                            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                <User className="h-5 w-5 text-slate-400" />
+                            </div>
+                            <Input
+                                id="userName"
+                                type="text"
+                                value={userName}
+                                onChange={(e) => setUserName(e.target.value)}
+                                placeholder="Upišite svoje ime..."
+                                className="w-full pl-10 py-4 text-lg border-2 border-slate-200 dark:border-slate-700 focus:border-primary-500 dark:focus:border-primary-400 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all duration-300 hover:border-slate-300 dark:hover:border-slate-600"
+                            />
                         </div>
-                        <Input
-                            id="userName"
-                            type="text"
-                            value={userName}
-                            onChange={(e) => setUserName(e.target.value)}
-                            placeholder="Upišite svoje ime..."
-                            className="w-full pl-10 py-4 text-lg border-2 border-slate-200 dark:border-slate-700 focus:border-primary-500 dark:focus:border-primary-400 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all duration-300 hover:border-slate-300 dark:hover:border-slate-600"
-                        />
+                    </div>
+
+                    <div className="space-y-3">
+                        <Label htmlFor="user-role" className="text-lg font-medium text-foreground">
+                            Ti si
+                        </Label>
+                        <div className="relative">
+                            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                                <Users className="h-5 w-5 text-slate-400" />
+                            </div>
+                            <Select value={role ?? ""} onValueChange={(value) => setRole(value)}>
+                                <SelectTrigger className="w-full pl-10 py-4 text-lg border-2 border-slate-200 dark:border-slate-700 focus:border-primary-500 dark:focus:border-primary-400 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all duration-300 hover:border-slate-300 dark:hover:border-slate-600">
+                                    <SelectValue placeholder="Odaberite svoju ulogu..." />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    <SelectItem value="1">Volonter</SelectItem>
+                                    <SelectItem value="2">Vozač</SelectItem>
+                                </SelectContent>
+                            </Select>
+                        </div>
                     </div>
                 </div>
+            </CardContent>
 
-                <div className="space-y-3">
-                    <Label htmlFor="user-role" className="text-lg font-medium text-foreground">
-                        Ti si
-                    </Label>
-                    <div className="relative">
-                        <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                            <Users className="h-5 w-5 text-slate-400" />
-                        </div>
-                        <Select value={role || ""} onValueChange={(value) => setRole(value)}>
-                            <SelectTrigger className="w-full pl-10 py-4 text-lg border-2 border-slate-200 dark:border-slate-700 focus:border-primary-500 dark:focus:border-primary-400 focus:ring-2 focus:ring-primary-200 dark:focus:ring-primary-800 transition-all duration-300 hover:border-slate-300 dark:hover:border-slate-600">
-                                <SelectValue placeholder="Odaberite svoju ulogu..." />
-                            </SelectTrigger>
-                            <SelectContent>
-                                <SelectItem value="1">Volonter</SelectItem>
-                                <SelectItem value="2">Vozač</SelectItem>
-                            </SelectContent>
-                        </Select>
-                    </div>
-                </div>
-            </div>
-
-            {/* Buttons */}
-            <div className="flex flex-col-reverse sm:flex-row justify-between gap-4 pt-4">
+            <CardFooter className="border-t border-border w-full flex-col-reverse items-stretch gap-4 sm:flex-row sm:items-center sm:justify-between">
                 <Button
                     onClick={handleBack}
                     variant="outline"
@@ -102,8 +108,8 @@ function UserInfo({ onSubmit, onBack }: UserInfoProps) {
                     <CheckCircle className="h-5 w-5 mr-2" />
                     Završi kviz
                 </Button>
-            </div>
-        </div>
+            </CardFooter>
+        </Card>
     );
 }
 


### PR DESCRIPTION
## Summary
- refactor the quiz user info screen to use Card, CardContent, and CardFooter for consistent styling
- keep the responsive button layout while moving the actions into the card footer
- guard the submit handler so it only triggers when a role is selected

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2b1efbb648320b89e1eaa309b7738