### PR TITLE
chore: harden changelog release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  changelog-release:
+    name: Generate release
+    runs-on: ubuntu-latest
+    if: contains(github.event.head_commit.message, '[skip ci]') == false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run changelog manager
+        id: changelog
+        uses: Enterwell/ChangelogManager-GitHub-Action@v3
+        with:
+          changelog_path: CHANGELOG.md
+          release_prefix: v
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Stop if no release is needed
+        if: steps.changelog.outputs.should_release != 'true'
+        run: echo "No new release entries detected"
+
+      - name: Update package.json version
+        if: steps.changelog.outputs.should_release == 'true'
+        env:
+          VERSION: ${{ steps.changelog.outputs.version }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = 'package.json';
+          const version = process.env.VERSION;
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          pkg.version = version;
+          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+          NODE
+
+      - name: Commit version bump
+        if: steps.changelog.outputs.should_release == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- package.json; then
+            echo "package.json already at version ${{ steps.changelog.outputs.version }}"
+            exit 0
+          fi
+          git add package.json
+          git commit -m "chore: release ${{ steps.changelog.outputs.tag }} [skip ci]"
+
+      - name: Push version bump
+        if: steps.changelog.outputs.should_release == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git push origin HEAD:main
+
+      - name: Create release tag
+        if: steps.changelog.outputs.should_release == 'true'
+        run: |
+          git tag -a "${{ steps.changelog.outputs.tag }}" -m "${{ steps.changelog.outputs.changelog }}"
+          git push origin "${{ steps.changelog.outputs.tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added Enterwell.ChangelogManager
+
 ## [1.0.0] - 2024-10-15
 ### Added
 - Implement quiz functionallity


### PR DESCRIPTION
## Summary
- guard the release workflow with the changelog manager's should_release output and add concurrency protection
- ensure package.json version bumps use a node script only when a release is required and skip redundant commits
- document the new changelog automation under the Unreleased section

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e3e5f2a6e08320a4857b9340248d9e